### PR TITLE
Support Find, etc. operations with channels

### DIFF
--- a/find.go
+++ b/find.go
@@ -66,6 +66,31 @@ func Min[T constraints.Ordered](list []T) (T, error) {
 	return min, nil
 }
 
+// MinCh returns the first instance of the minimum element
+// received from the given channel.
+func MinCh[T constraints.Ordered](ch <-chan T) (T, error) {
+	init := false
+	var min T
+	for {
+		v, ok := <-ch
+		if !ok {
+			break
+		}
+		if !init {
+			min = v
+			init = true
+		}
+		if min > v {
+			min = v
+		}
+	}
+
+	if !init {
+		return min, fmt.Errorf("cannot find minimum value of empty chan")
+	}
+	return min, nil
+}
+
 // Max returns the first instance of the maximum element
 // present in the given slice.
 func Max[T constraints.Ordered](list []T) (T, error) {

--- a/find.go
+++ b/find.go
@@ -17,6 +17,20 @@ func IndexOf[T comparable](list []T, elem T) int {
 	return -1
 }
 
+func IndexOfCh[T comparable](ch <-chan T, elem T) int {
+	i := 0
+	for {
+		v, ok := <-ch
+		if !ok {
+			return -1
+		}
+		if v == elem {
+			return i
+		}
+		i++
+	}
+}
+
 // LastIndexOf returns the index of the last instance of the given element in
 // the given slice. If the given element is not present, -1 is returned.
 func LastIndexOf[T comparable](list []T, elem T) int {

--- a/find.go
+++ b/find.go
@@ -149,3 +149,25 @@ func Max[T constraints.Ordered](list []T) (T, error) {
 	}
 	return max, nil
 }
+
+func MaxCh[T constraints.Ordered](ch <-chan T) (T, error) {
+	init := false
+	var max T
+	for {
+		v, ok := <-ch
+		if !ok {
+			break
+		}
+		if !init {
+			max = v
+			init = true
+		}
+		if max < v {
+			max = v
+		}
+	}
+	if !init {
+		return max, fmt.Errorf("cannot find maximum value of empty chan")
+	}
+	return max, nil
+}

--- a/find.go
+++ b/find.go
@@ -61,16 +61,25 @@ func LastIndexOfCh[T comparable](ch <-chan T, elem T) int {
 
 // Find returns the element present and an error if the item is not present
 func Find[T comparable](list []T, is func(a T) bool) (T, error) {
-	var empty T
-	if len(list) == 0 {
-		return empty, fmt.Errorf("cannot find item in empty list")
-	}
 	for _, elem := range list {
 		if is(elem) {
 			return elem, nil
 		}
 	}
+	var empty T
 	return empty, fmt.Errorf("could not find item in list")
+}
+
+func FindCh[T comparable](ch <-chan T, is func(a T) bool) (T, error) {
+	for {
+		elem, ok := <-ch
+		if !ok {
+			return elem, fmt.Errorf("cannot find item in empty chan")
+		}
+		if is(elem) {
+			return elem, nil
+		}
+	}
 }
 
 // Min returns the first instance of the minimum element

--- a/find.go
+++ b/find.go
@@ -44,6 +44,21 @@ func LastIndexOf[T comparable](list []T, elem T) int {
 	return -1
 }
 
+func LastIndexOfCh[T comparable](ch <-chan T, elem T) int {
+	i := 0
+	lastIndex := -1
+	for {
+		v, ok := <-ch
+		if !ok {
+			return lastIndex
+		}
+		if v == elem {
+			lastIndex = i
+		}
+		i++
+	}
+}
+
 // Find returns the element present and an error if the item is not present
 func Find[T comparable](list []T, is func(a T) bool) (T, error) {
 	var empty T

--- a/find_test.go
+++ b/find_test.go
@@ -354,3 +354,50 @@ func TestMinError(t *testing.T) {
 		t.Errorf("TestMinError MinCh: expected err, got nil and %v min", minCh)
 	}
 }
+
+func TestMaxInt(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []int
+		expected int
+	}{
+		{
+			"happyCase",
+			[]int{14, 8, 9, 12},
+			14,
+		},
+		{
+			"negatives",
+			[]int{-13, -11, -98, 45, 0, 199, -2},
+			199,
+		},
+	}
+	for _, tc := range cases {
+		actMax, err := Max(tc.input)
+
+		if actMax != tc.expected || err != nil {
+			t.Errorf("TestMaxInt %v: expected %v, got %v, err: %v", tc.name, tc.expected, actMax, err)
+		}
+
+		ch := sliceToChan(tc.input)
+		actMaxCh, err := MaxCh(ch)
+		if actMaxCh != tc.expected || err != nil {
+			t.Errorf("TestMaxInt MaxCh %v: expected %v, got %v, err: %v", tc.name, tc.expected, actMaxCh, err)
+		}
+	}
+}
+
+func TestMaxError(t *testing.T) {
+	list := make([]int, 0)
+
+	max, err := Max(list)
+	if err == nil {
+		t.Errorf("TestMaxError: expected err, got nil and %v max", max)
+	}
+
+	ch := sliceToChan(list)
+	maxCh, err := MaxCh(ch)
+	if err == nil {
+		t.Errorf("TestMaxError MaxCh: expected err, got nil and %v max", maxCh)
+	}
+}

--- a/find_test.go
+++ b/find_test.go
@@ -15,7 +15,7 @@ func sliceToChan[T any](list []T) <-chan T {
 	return ch
 }
 
-func TestIndexOfIndexOfChInt(t *testing.T) {
+func TestIndexOfInt(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    []int
@@ -57,13 +57,13 @@ func TestIndexOfIndexOfChInt(t *testing.T) {
 	for _, tc := range cases {
 		actIndexOf := IndexOf(tc.input, tc.elem)
 		if actIndexOf != tc.expected {
-			t.Errorf("TestIndexOfIndexOfChInt IndexOf %v: expected %v, got %v", tc.name, tc.elem, actIndexOf)
+			t.Errorf("TestIndexOfInt %v: expected %v, got %v", tc.name, tc.elem, actIndexOf)
 		}
 
 		ch := sliceToChan(tc.input)
 		actIndexOfCh := IndexOfCh(ch, tc.elem)
 		if actIndexOfCh != tc.expected {
-			t.Errorf("TestIndexOfIndexOfChInt IndexOfCh %v: expected %v, got %v", tc.name, tc.elem, actIndexOfCh)
+			t.Errorf("TestIndexOfInt IndexOfCh %v: expected %v, got %v", tc.name, tc.elem, actIndexOfCh)
 		}
 	}
 }
@@ -90,9 +90,15 @@ func TestIndexOfString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := IndexOf(tc.input, tc.elem)
-		if actual != tc.expected {
-			t.Errorf("TestIndexOfString %v: expected %v, got %v", tc.name, tc.elem, actual)
+		actIndexOf := IndexOf(tc.input, tc.elem)
+		if actIndexOf != tc.expected {
+			t.Errorf("TestIndexOfString %v: expected %v, got %v", tc.name, tc.elem, actIndexOf)
+		}
+
+		ch := sliceToChan(tc.input)
+		actIndexOfCh := IndexOfCh(ch, tc.elem)
+		if actIndexOfCh != tc.expected {
+			t.Errorf("TestIndexOfString IndexOfCh %v: expected %v, got %v", tc.name, tc.elem, actIndexOfCh)
 		}
 	}
 }
@@ -131,9 +137,15 @@ func TestLastIndexOfInt(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := LastIndexOf(tc.input, tc.elem)
-		if actual != tc.expected {
-			t.Errorf("TestLastIndexOfInt %v: expected %v, got %v", tc.name, tc.elem, actual)
+		actLastIndexOf := LastIndexOf(tc.input, tc.elem)
+		if actLastIndexOf != tc.expected {
+			t.Errorf("TestLastIndexOfInt %v: expected %v, got %v", tc.name, tc.elem, actLastIndexOf)
+		}
+
+		ch := sliceToChan(tc.input)
+		actLastIndexOfCh := LastIndexOfCh(ch, tc.elem)
+		if actLastIndexOfCh != tc.expected {
+			t.Errorf("TestLastIndexOfInt LastIndexOfCh %v: expected %v, got %v", tc.name, tc.elem, actLastIndexOfCh)
 		}
 	}
 }
@@ -172,9 +184,15 @@ func TestLastIndexOfString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := LastIndexOf(tc.input, tc.elem)
-		if actual != tc.expected {
-			t.Errorf("TestLastIndexOfString %v: expected %v, got %v", tc.name, tc.expected, actual)
+		actLastIndexOf := LastIndexOf(tc.input, tc.elem)
+		if actLastIndexOf != tc.expected {
+			t.Errorf("TestLastIndexOfString %v: expected %v, got %v", tc.name, tc.expected, actLastIndexOf)
+		}
+
+		ch := sliceToChan(tc.input)
+		actLastIndexOfCh := LastIndexOfCh(ch, tc.elem)
+		if actLastIndexOfCh != tc.expected {
+			t.Errorf("TestLastIndexOfString LastIndexOfCh %v: expected %v, got %v", tc.name, tc.expected, actLastIndexOfCh)
 		}
 	}
 }

--- a/find_test.go
+++ b/find_test.go
@@ -199,11 +199,10 @@ func TestLastIndexOfString(t *testing.T) {
 
 func TestFindInt(t *testing.T) {
 	cases := []struct {
-		name        string
-		input       []int
-		pred        func(elem int) bool
-		expected    int
-		expectedErr bool
+		name     string
+		input    []int
+		pred     func(elem int) bool
+		expected int
 	}{
 		{
 			"happyCase",
@@ -212,7 +211,6 @@ func TestFindInt(t *testing.T) {
 				return elem == 2
 			},
 			2,
-			false,
 		},
 		{
 			"expandedCase",
@@ -221,16 +219,35 @@ func TestFindInt(t *testing.T) {
 				return elem == 412
 			},
 			412,
-			false,
 		},
+	}
+	for _, tc := range cases {
+		actFind, err := Find(tc.input, tc.pred)
+
+		if err != nil || actFind != tc.expected {
+			t.Errorf("TestFindInt %v: expected %v, got %v, err %v", tc.name, tc.expected, actFind, err)
+		}
+
+		ch := sliceToChan(tc.input)
+		actFindCh, err := FindCh(ch, tc.pred)
+		if err != nil || actFindCh != tc.expected {
+			t.Errorf("TestFindInt FindCh %v: expected %v, got %v, err %v", tc.name, tc.expected, actFindCh, err)
+		}
+	}
+}
+
+func TestFindIntErr(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []int
+		pred  func(elem int) bool
+	}{
 		{
 			"doesNotExist",
 			[]int{1, 4, 3},
 			func(elem int) bool {
 				return elem == 412
 			},
-			412,
-			true,
 		},
 		{
 			"emptySlice",
@@ -238,33 +255,28 @@ func TestFindInt(t *testing.T) {
 			func(elem int) bool {
 				return elem == 412
 			},
-			412,
-			true,
 		},
 	}
+
 	for _, tc := range cases {
-		actual, err := Find(tc.input, tc.pred)
-		if tc.expectedErr && err == nil {
-			t.Errorf("TestFindInt %v: expected an error and got nil", tc.name)
+		actFind, err := Find(tc.input, tc.pred)
+		if err == nil {
+			t.Errorf("TestFindIntErr %v: wanted err but got nil, found :%v", tc.name, actFind)
 		}
-
-		if !tc.expectedErr && err != nil {
-			t.Errorf("TestFindInt %v: did not expect error but got %v", tc.name, err)
-		}
-
-		if !tc.expectedErr && actual != tc.expected {
-			t.Errorf("TestFindInt %v: expected %v, got %v", tc.name, tc.expected, actual)
+		ch := sliceToChan(tc.input)
+		actFindCh, err := FindCh(ch, tc.pred)
+		if err == nil {
+			t.Errorf("TestFindIntErr FindCh %v: wanted err but got nil, found :%v", tc.name, actFindCh)
 		}
 	}
 }
 
 func TestFindString(t *testing.T) {
 	cases := []struct {
-		name        string
-		input       []string
-		pred        func(elem string) bool
-		expected    string
-		expectedErr bool
+		name     string
+		input    []string
+		pred     func(elem string) bool
+		expected string
 	}{
 		{
 			"happyCase",
@@ -273,7 +285,6 @@ func TestFindString(t *testing.T) {
 				return elem == "def"
 			},
 			"def",
-			false,
 		},
 		{
 			"expandedCase",
@@ -282,39 +293,17 @@ func TestFindString(t *testing.T) {
 				return elem == "hijk"
 			},
 			"hijk",
-			false,
-		},
-		{
-			"doesNotExist",
-			[]string{"abc", "def", "hijk"},
-			func(elem string) bool {
-				return elem == "lmnop"
-			},
-			"lmnop",
-			true,
-		},
-		{
-			"emptySlice",
-			[]string{},
-			func(elem string) bool {
-				return elem == "def"
-			},
-			"def",
-			true,
 		},
 	}
 	for _, tc := range cases {
-		actual, err := Find(tc.input, tc.pred)
-		if tc.expectedErr && err == nil {
-			t.Errorf("TestFindString %v: expected an error and got nil", tc.name)
+		actFind, err := Find(tc.input, tc.pred)
+		if err != nil || actFind != tc.expected {
+			t.Errorf("TestFindString %v: expected %v, got %v, err %v", tc.name, tc.expected, actFind, err)
 		}
-
-		if !tc.expectedErr && err != nil {
-			t.Errorf("TestFindString %v: did not expect error but got %v", tc.name, err)
-		}
-
-		if !tc.expectedErr && actual != tc.expected {
-			t.Errorf("TestFindString %v: expected %v, got %v", tc.name, tc.expected, actual)
+		ch := sliceToChan(tc.input)
+		actFindCh, err := FindCh(ch, tc.pred)
+		if err != nil || actFindCh != tc.expected {
+			t.Errorf("TestFindString FindCh %v: expected %v, got %v, err %v", tc.name, tc.expected, actFindCh, err)
 		}
 	}
 }

--- a/find_test.go
+++ b/find_test.go
@@ -321,90 +321,47 @@ func TestFindString(t *testing.T) {
 
 func TestMinInt(t *testing.T) {
 	cases := []struct {
-		name        string
-		input       []int
-		expected    int
-		expectedErr bool
+		name     string
+		input    []int
+		expected int
 	}{
 		{
 			"happyCase",
 			[]int{14, 8, 9, 12},
 			8,
-			false,
 		},
 		{
-			"emptySlice",
-			[]int{},
-			8,
-			true,
+			"negatives",
+			[]int{-13, -11, -98, 45, 0, 199, -2},
+			-98,
 		},
 	}
 	for _, tc := range cases {
-		actual, err := Min(tc.input)
-		if tc.expectedErr && err == nil {
-			t.Errorf("TestMinInt %v: expected an error and got nil", tc.name)
+		actMin, err := Min(tc.input)
+
+		if actMin != tc.expected || err != nil {
+			t.Errorf("TestMinInt %v: expected %v, got %v, err: %v", tc.name, tc.expected, actMin, err)
 		}
 
-		if !tc.expectedErr && err != nil {
-			t.Errorf("TestMinInt %v: did not expect error but got %v", tc.name, err)
-		}
-
-		if !tc.expectedErr && actual != tc.expected {
-			t.Errorf("TestMinInt %v: expected %v, got %v", tc.name, tc.expected, actual)
+		ch := sliceToChan(tc.input)
+		actMinCh, err := MinCh(ch)
+		if actMinCh != tc.expected || err != nil {
+			t.Errorf("TestMinInt MinCh %v: expected %v, got %v, err: %v", tc.name, tc.expected, actMinCh, err)
 		}
 	}
 }
 
-func TestMinCh(t *testing.T) {
-	cases := []struct {
-		name     string
-		expected int
-		fill     func(ch chan<- int)
-	}{
-		{
-			name:     "happyCase",
-			expected: 0,
-			fill: func(ch chan<- int) {
-				i := 0
-				for i < 10 {
-					ch <- i
-					i++
-				}
-				close(ch)
-			},
-		},
-		{
-			name:     "nonTrivial",
-			expected: -15,
-			fill: func(ch chan<- int) {
-				i := 0
-				ch <- -10
-				for i < 100 {
-					ch <- (i * 2) % 3
-					i++
-				}
-				ch <- -15
-				close(ch)
-			},
-		},
-	}
+func TestMinError(t *testing.T) {
+	list := make([]int, 0)
 
-	for _, tc := range cases {
-		ch := make(chan int)
-		go tc.fill(ch)
-		actual, err := MinCh(ch)
-		if err != nil {
-			t.Errorf("TestMinCh %v: expected %v, got %v", tc.name, tc.expected, actual)
-		}
-	}
-}
-
-func TestMinChError(t *testing.T) {
-	ch := make(chan int)
-	close(ch)
-
-	min, err := MinCh(ch)
+	min, err := Min(list)
 	if err == nil {
-		t.Errorf("TestMinChError: expected err, got nil and %v min", min)
+		t.Errorf("TestMinError: expected err, got nil and %v min", min)
+	}
+
+	ch := sliceToChan(list)
+	minCh, err := MinCh(ch)
+	if err == nil {
+		t.Errorf("TestMinError MinCh: expected err, got nil and %v min", minCh)
 	}
 }

--- a/find_test.go
+++ b/find_test.go
@@ -4,7 +4,18 @@ import (
 	"testing"
 )
 
-func TestIndexOfInt(t *testing.T) {
+func sliceToChan[T any](list []T) <-chan T {
+	ch := make(chan T)
+	go func() {
+		for _, v := range list {
+			ch <- v
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func TestIndexOfIndexOfChInt(t *testing.T) {
 	cases := []struct {
 		name     string
 		input    []int
@@ -44,9 +55,15 @@ func TestIndexOfInt(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := IndexOf(tc.input, tc.elem)
-		if actual != tc.expected {
-			t.Errorf("TestIndexOfInt %v: expected %v, got %v", tc.name, tc.elem, actual)
+		actIndexOf := IndexOf(tc.input, tc.elem)
+		if actIndexOf != tc.expected {
+			t.Errorf("TestIndexOfIndexOfChInt IndexOf %v: expected %v, got %v", tc.name, tc.elem, actIndexOf)
+		}
+
+		ch := sliceToChan(tc.input)
+		actIndexOfCh := IndexOfCh(ch, tc.elem)
+		if actIndexOfCh != tc.expected {
+			t.Errorf("TestIndexOfIndexOfChInt IndexOfCh %v: expected %v, got %v", tc.name, tc.elem, actIndexOfCh)
 		}
 	}
 }


### PR DESCRIPTION
Add channel operations for `find.go` functions (and associated tests). 